### PR TITLE
Return travis builds on xcode, update readme

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,32 +2,9 @@ cache:
   directories:
   - $HOME/.m2
 
-#env:
-#  - GRAVIS="https://raw.githubusercontent.com/DanySK/Gravis-CI/master/"
-
 matrix:
   include:
-#  - os: windows
-#    language: bash
-#    before_install:
-#    - curl "${GRAVIS}.install-jdk-travis.sh" --output .install-jdk-travis.sh
-#    - source ~/.install-jdk-travis.sh
-#    - curl "${GRAVIS}.install-maven-travis.sh" --output .install-maven-travis.sh
-#    - source ~/.install-maven-travis.sh
-#
-##    - choco install jdk8 maven
-##    - export JAVA_HOME="C:\Program Files\Java\jdk1.8.0_211"
-##    - export PATH=$PATH:"C:\Program Files\Java\jdk1.8.0_211\bin\":"C:\ProgramData\chocolatey\lib\maven\"
-#    before_cache:
-#    - curl "${GRAVIS}.clean_gradle_cache.sh" --output .clean_gradle_cache.sh
-#    - bash .clean_gradle_cache.sh
-#    cache:
-#      directories:
-#      # This avoids re-downloading the JDK every time, but Travis recommends not to do it
-#      # - $HOME/.jabba/
-#      # If you use Gradle, you may want to save some time with caching
-#      - $HOME/.gradle/caches/
-#      - $HOME/.gradle/wrapper/
+  # Travis poorly supports windows with jdk
   - os: linux
     language: java
     dist: trusty
@@ -36,12 +13,17 @@ matrix:
     language: java
     dist: trusty
     jdk: oraclejdk8
-#  - os: osx
-#    language: java
-#    osx_image: xcode9.3 # Further versions use jdk 10+
-#  - os: osx
-#    language: java
-#    osx_image: xcode10
+  - os: linux
+    language: java
+    dist: trusty
+    jdk: openjdk11
+  - os: linux
+    language: java
+    dist: trusty
+    jdk: oraclejdk11
+  - os: osx
+    language: java
+    osx_image: xcode9.3 # Further versions use java 13+
 
 install:
 - mvn org.apache.maven.plugins:maven-install-plugin:2.3.1:install-file -Dfile=${TRAVIS_BUILD_DIR}/lib/org.RDKit.jar -DgroupId=org.rdkit -DartifactId=rdkit -Dversion=1.0.0 -Dpackaging=jar

--- a/README.md
+++ b/README.md
@@ -160,26 +160,13 @@ Additional reserved property names:
     * Return boolean answer: does specified `node` object have substructure match provided by `smiles_string`.
 
 ---
-
-# Results overview 
-
-## What was achieved
-
-1) Implementation of exact search (100%)  
-2) Implementation of substructure search (90%, several minor bugs)  
-3) Implementation of condition based graph traversal - usage of function calls in complex queries (100%)
-4) Implementation of similarity search (70%, major performance issues)    
-5) Coverage with unit tests (80%, not all invalid arguments for procedures are tested)
-
 ## What remains to be done
 
-<!-- 0) Query features in substructure search (blocking of position in molecule from further substitution; using atom lists on certain positions in molecule) -->
 1) Speed up batch tasks by utilizing several threads (currently waiting for resolving issue on native level)  
 2) Speed up the `similarity search` procedures  
 3) Solve minor bugs (todos) like unclosed `query` object during SSS  
 
-## What problems were encountered
+## Java requirements
 
-1) Compatability of native libraries for win64 (beginning of the development)  
-2) Lazy streams evaluation and not resolved issue with `query` object during SSS  
-3) Parallelization of stream evaluations    
+Plugin supports openjdk and oraclejdk java versions (< 12).  
+Further versions upgraded _security sensitive fields_ [policy](https://bugs.openjdk.java.net/browse/JDK-8210496), those are currently not supported.  

--- a/README.md
+++ b/README.md
@@ -160,6 +160,16 @@ Additional reserved property names:
     * Return boolean answer: does specified `node` object have substructure match provided by `smiles_string`.
 
 ---
+# Results overview 
+
+## What was achieved
+
+1) Implementation of exact search (100%)  
+2) Implementation of substructure search (90%, several minor bugs)  
+3) Implementation of condition based graph traversal - usage of function calls in complex queries (100%)
+4) Implementation of similarity search (70%, major performance issues)    
+5) Coverage with unit tests (80%, not all invalid arguments for procedures are tested)
+
 ## What remains to be done
 
 1) Speed up batch tasks by utilizing several threads (currently waiting for resolving issue on native level)  


### PR DESCRIPTION
Returned builds on xcode, only `9.3`. `xcode9.4` already uses java 13+, which is not acceptable for the project.  

Removed GSOC details (issues during development, what remains to be done).  